### PR TITLE
fix: HTTP 환경에서 쿠키 인증 401 에러 수정

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -37,10 +37,10 @@ export class AuthController {
   ) {}
 
   private getCookieOptions() {
-    const isProduction = this.configService.get('NODE_ENV') === 'production';
+    const useSecure = this.configService.get('COOKIE_SECURE', 'false') === 'true';
     return {
       ...COOKIE_OPTIONS,
-      secure: isProduction,
+      secure: useSecure,
     };
   }
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -13,6 +13,7 @@ BACKEND_PORT=3432
 JWT_SECRET=changeme_generate_with_openssl_rand_base64_32
 JWT_EXPIRATION=7d
 FRONTEND_URL=http://localhost
+COOKIE_SECURE=false  # HTTPS 사용 시 true로 변경
 
 # --- Admin (첫 배포 시 관리자 계정 자동 생성) ---
 ADMIN_ID=admin

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -55,6 +55,7 @@ services:
       JWT_SECRET: ${JWT_SECRET}
       JWT_EXPIRATION: ${JWT_EXPIRATION:-7d}
       FRONTEND_URL: ${FRONTEND_URL:-http://localhost}
+      COOKIE_SECURE: ${COOKIE_SECURE:-false}
       ADMIN_ID: ${ADMIN_ID:-}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD:-}
       NODE_OPTIONS: "--max-old-space-size=256"


### PR DESCRIPTION
## Summary
- 프로덕션 HTTP 환경에서 쿠키 `secure: true`로 인해 브라우저가 쿠키를 전송하지 않아 401 발생
- `COOKIE_SECURE` 환경변수로 분리하여 HTTP/HTTPS 환경 모두 지원

## Test plan
- [ ] HTTP 환경에서 로그인 → 쿠키 정상 전송 → 401 미발생 확인
- [ ] HTTPS 환경에서 `COOKIE_SECURE=true` 설정 후 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)